### PR TITLE
Add sleep time

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,8 @@
 default:
   DATA_DIR: "data"
   PROJECT_ROOT: "."
+  FRED_SLEEP_TIME: "1"
 docker:
   DATA_DIR: "/data"
   PROJECT_ROOT: "/Rscripts"
+  FRED_SLEEP_TIME: "2"

--- a/unemploymentDataProcessor.R
+++ b/unemploymentDataProcessor.R
@@ -206,7 +206,7 @@ get_fred_series_with_state_id <- function(series, metric_name, sleep = FALSE, st
     select(rptdate, st, metric, value)
   
   # sleep to avoid a rate limitation, if need be
-  if(sleep) Sys.sleep(1)
+  if(sleep) Sys.sleep(config::get("FRED_SLEEP_TIME"))
   
   return(df)
 }


### PR DESCRIPTION
Adds a configurable sleeptime parameter for FRED downloads;  defaults to 2 seconds for the build user, which allows for the ability to slow down fred requests and hopefully not get rate limited.